### PR TITLE
Replace RabbitMQ with Amazon SQS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,3 @@ ENV/
 
 # mypy
 .mypy_cache/
-
-# persisted queue data
-/rabbitmq

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN mkdir -p /mnt/inspect
 
 RUN yum install centos-release-scl -y \
     && yum-config-manager --enable centos-sclo-rh-testing \
-    && yum install which rh-python36 rh-python36-python-pip -y
+    && yum install which rh-python36 rh-python36-python-pip libcurl-devel gcc -y
 
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN scl enable rh-python36 'pip install pipenv \
+RUN PYCURL_SSL_LIBRARY=nss scl enable rh-python36 'pip install pipenv \
     && pipenv install --system \
     && rm -rf Pipfile*'
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 click = "*"
 kombu = "*"
+"boto3" = "*"
+pycurl = "*"
 
 [dev-packages]
 nose = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ecc0b66bbe745201a8a9906ff666ce824d655d2af10073defb3c1cd9875dd4f"
+            "sha256": "9e8b3aac87d916cdeb2e23bdee2db5245c86d65050344851a49ff0bd1796198f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,25 @@
     "default": {
         "amqp": {
             "hashes": [
-                "sha256:eed41946890cd43e8dee44a316b85cf6fee5a1a34bb4a562b660a358eb529e1b",
-                "sha256:073dd02fdd73041bffc913b767866015147b61f2a9bc104daef172fc1a0066eb"
+                "sha256:073dd02fdd73041bffc913b767866015147b61f2a9bc104daef172fc1a0066eb",
+                "sha256:eed41946890cd43e8dee44a316b85cf6fee5a1a34bb4a562b660a358eb529e1b"
             ],
             "version": "==2.3.2"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:19d479abad241512051b11f681b93f37b1e6b03d8f2907daae94b4ca8d0da738",
+                "sha256:38a811f3335b08690182fdbddb07f0cb5e8f0b5bccbcf9ef606ed2a2508a9fd7"
+            ],
+            "index": "pypi",
+            "version": "==1.7.30"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:1f6d0a135c9505e0840b675e6bd6b556c85df2e63212ac6850f77edf9f68311a",
+                "sha256:8dac26094f3dbebd2849c0774f050daad3f1abf1b35fad7525916a36372fe009"
+            ],
+            "version": "==1.10.30"
         },
         "click": {
             "hashes": [
@@ -31,12 +46,69 @@
             "index": "pypi",
             "version": "==6.7"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
+                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
+            ],
+            "version": "==0.9.3"
+        },
         "kombu": {
             "hashes": [
-                "sha256:b274db3a4eacc4789aeb24e1de3e460586db7c4fc8610f7adcc7a3a1709a60af",
-                "sha256:86adec6c60f63124e2082ea8481bbe4ebe04fde8ebed32c177c7f0cd2c1c9082"
+                "sha256:86adec6c60f63124e2082ea8481bbe4ebe04fde8ebed32c177c7f0cd2c1c9082",
+                "sha256:b274db3a4eacc4789aeb24e1de3e460586db7c4fc8610f7adcc7a3a1709a60af"
             ],
+            "index": "pypi",
             "version": "==4.2.1"
+        },
+        "pycurl": {
+            "hashes": [
+                "sha256:164ba8e7675b9dec38f4eb25ee8a071bad7f66ab5c481547f3db43b0d2e7a8eb",
+                "sha256:1b97ae53ab2c515cbcaa5d563d443ed8e9630e8a94ba07d4bfbe287c5d89c472",
+                "sha256:2a7d4d7bb0194b1849c62ecaccbc28298a4372c3edbdd3c3e61761d705311925",
+                "sha256:384e541bb948c5d0a82f20fc24cfa4c17b80d366089e3c1911c812c1dc446ab7",
+                "sha256:43231bf2bafde923a6d9bb79e2407342a5f3382c1ef0a3b2e491c6a4e50b91aa",
+                "sha256:50a10a6ea1e184aef5261f1df1187598271d5b8b9ab6ef025ef574dd796df7fb",
+                "sha256:70230a862178cf37d0922c0974b759577e55253c9cfe72298400881d6432cf99",
+                "sha256:7d57195f96a49c173b052617bd56589326b4f91ec1fccb52522ae96f8f240bde",
+                "sha256:7f457eac8ed02ae06655993399b4cf8c11a5202f3a01b255de300dced8c3e3d5",
+                "sha256:920f7ee8b231fb009594e6f35aa7ed829ff74a5595efa9800fd1d6656106c2a8",
+                "sha256:a75d1d81a5e65cf53ddadd36ca89083f29134e027a310ae0c3e97570789db1db",
+                "sha256:d0f26b811defeb0b9697afdf4c3aa3cc42781185234e0b73ca58bb7639f6786c",
+                "sha256:ea44d26aa092c39fe1a07c75adb453ab46c5d1433e8baad02edbf2c1d2bc90f5"
+            ],
+            "index": "pypi",
+            "version": "==7.43.0.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==2.7.3"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
+                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+            ],
+            "version": "==0.1.13"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
         },
         "vine": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -56,11 +56,29 @@ Finally, if you need to install a dev only dependency, use:
 
 ### Running
 
+Before running, you must have the following environment variables set so houndigrade can talk to Amazon SQS to share its results:
+
+    - `QUEUE_CONNECTION_URL`
+    - `AWS_SQS_QUEUE_NAME_PREFIX`
+
+`AWS_SQS_QUEUE_NAME_PREFIX` should match what you use when running cloudigrade, and that is probably `${USER}-`.
+
+`QUEUE_CONNECTION_URL` must be a well-formed SQS URL that includes your Amazon SQS access key and secret key. Many Amazon keys have URL-unfriendly characters. You may want to use a small helper script like this to generate a valid URL:
+
+```python
+from os import environ
+from urllib.parse import quote
+print('sqs://{}:{}@'.format(
+    quote(environ['AWS_SQS_ACCESS_KEY_ID'], safe=''),
+    quote(environ['AWS_SQS_SECRET_ACCESS_KEY'], safe='')
+))
+```
+
 To run houndigrade locally use docker-compose
 
     docker-compose up
 
-This will start the queue, the houndigrade container, mount provided block 
+This will start the houndigrade container, mount provided block
 devices inside said container, and run a scan against it, placing the results
  on the queue. The queue can be accessed at [localhost:15672](http://localhost:15672) with `guest/guest` being the default credentials.
 
@@ -69,11 +87,11 @@ devices inside said container, and run a scan against it, placing the results
 To run all local tests as well as our code-quality checking commands:
 
     tox
-    
+
 To run just our code-quality checking commands:
 
     tox -e flake8
-    
+
 To run just our tests:
 
     tox -e py36

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,25 +5,12 @@ services:
     build: .
     entrypoint: ./entrypoint.sh
     environment:
-      - RABBITMQ_URL=amqp://guest:guest@queue:5672/%2F
-      - RABBITMQ_EXCHANGE_NAME=houndigrade_inspectigrade
-      - RABBITMQ_QUEUE_NAME=inspection_results
+      - QUEUE_CONNECTION_URL
+      - RESULTS_QUEUE_NAME=${AWS_SQS_QUEUE_NAME_PREFIX}inspection_results
     volumes:
       - ./docker/dev-entrypoint.sh:/opt/houndigrade/entrypoint.sh
       - ./docker/rh_disk:/dev/rh_disk
       - ./docker/nrh_disk:/dev/nrh_disk
       - ./docker/both_disk:/dev/both_disk
       - /dev:/dev
-    depends_on:
-      - queue
     privileged: true
-  queue:
-    image: rabbitmq:management-alpine
-    hostname: cloudiqueue
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    environment:
-      - RABBITMQ_DISK_FREE_LIMIT={mem_relative, 1.5}
-    volumes:
-      - ./rabbitmq:/var/lib/rabbitmq

--- a/houndigrade/cli.py
+++ b/houndigrade/cli.py
@@ -123,12 +123,12 @@ def report_results(results):
         results (dict): The results of the finished inspection.
 
     """
-    queue_name = os.getenv('RABBITMQ_QUEUE_NAME')
+    queue_name = os.getenv('RESULTS_QUEUE_NAME')
 
-    exchange = Exchange(os.getenv('RABBITMQ_EXCHANGE_NAME'), durable=True)
+    exchange = Exchange(os.getenv('EXCHANGE_NAME'), durable=True)
     queue = Queue(queue_name, exchange=exchange, routing_key=queue_name)
 
-    with Connection(os.getenv('RABBITMQ_URL')) as conn:
+    with Connection(os.getenv('QUEUE_CONNECTION_URL')) as conn:
         producer = conn.Producer(serializer='json')
         producer.publish(
             results,


### PR DESCRIPTION
kill the rabbit https://youtu.be/Yxiv3CBMS4M

https://github.com/cloudigrade/cloudigrade/issues/296

This PR does a few things:
- make environment variable names more generic so it doesn't look like we need RabbitMQ
- drop the RabbitMQ container from `docker-compose.yml`
- updates README with new instructions for running locally with docker compose